### PR TITLE
detail the expected user order

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.3.31'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.41'
 }
 
 group 'coroutines'

--- a/src/tasks/Aggregation.kt
+++ b/src/tasks/Aggregation.kt
@@ -17,4 +17,5 @@ TODO: Write aggregation code.
 fun List<User>.aggregate(): List<User> =
     groupBy { it.login }
         .map { (login, group) -> User(login, group.sumBy { it.contributions }) }
+        .sortedBy { it.login }
         .sortedByDescending { it.contributions }

--- a/test/tasks/AggregationKtTest.kt
+++ b/test/tasks/AggregationKtTest.kt
@@ -10,9 +10,11 @@ class AggregationKtTest {
         val actual = listOf(
             User("Alice", 1), User("Bob", 3),
             User("Alice", 2), User("Bob", 7),
+            User("Beth", 3), User("Beth", 7),
             User("Charlie", 3), User("Alice", 5)
         ).aggregate()
         val expected = listOf(
+            User("Beth", 10),
             User("Bob", 10),
             User("Alice", 8),
             User("Charlie", 3)


### PR DESCRIPTION
With this PR I propose to detail the expected user order for users with same _contributions_ in [Aggregation.kt](https://github.com/kotlin-hands-on/intro-coroutines/blob/solutions/src/tasks/Aggregation.kt#L17-L20).
To Highlight my point, I adapted the test respectively the expected user list: 
- added _Beth_ (with the same number of contributions as _Bob_) to the expected user list ([1](https://github.com/lotharschulz/intro-coroutines/blob/solutions/test/tasks/AggregationKtTest.kt#L13), [2](https://github.com/lotharschulz/intro-coroutines/blob/solutions/test/tasks/AggregationKtTest.kt#L17)).

The [existing _aggregate_ implementation](https://github.com/kotlin-hands-on/intro-coroutines/blob/solutions/src/tasks/Aggregation.kt#L17-L20) failed with the [adapted expected user list](https://github.com/lotharschulz/intro-coroutines/blob/solutions/test/tasks/AggregationKtTest.kt#L16-L20) in my tests. 
However, the [test passes with the adapted expected user list](https://github.com/lotharschulz/intro-coroutines/blob/solutions/test/tasks/AggregationKtTest.kt#L9-L23) with the [proposed detailed user order](https://github.com/lotharschulz/intro-coroutines/blob/solutions/src/tasks/Aggregation.kt#L20).

Please note: the key selector of fun [groupBy](https://github.com/kotlin-hands-on/intro-coroutines/blob/solutions/src/tasks/Aggregation.kt#L18) recognizes _Bob_ first and _Beth_ afterwards, because Bob is part of the [second element](https://github.com/lotharschulz/intro-coroutines/blob/solutions/test/tasks/AggregationKtTest.kt#L11) of the [_actual_ user list](https://github.com/kotlin-hands-on/intro-coroutines/blob/solutions/test/tasks/AggregationKtTest.kt#L10-L13). The existing tests would pass in case _Beth_ would be recognized by the key selector prior to Bob (e.g. as part of the first user list element).

---

Additional change: [gradle patch version bump](https://github.com/kotlin-hands-on/intro-coroutines/commit/fcb08ca0e834175be9fb5ad63531139f8e4fa7cd).