### PR TITLE
Added reactive solutions for 'testing' & 'cancellation'

### DIFF
--- a/src/tasks/Request8Rx.kt
+++ b/src/tasks/Request8Rx.kt
@@ -2,35 +2,30 @@ package tasks
 
 import contributors.*
 import io.reactivex.Observable
+import io.reactivex.Scheduler
 import io.reactivex.Single
-import io.reactivex.rxkotlin.toObservable
-import io.reactivex.rxkotlin.zipWith
 import io.reactivex.schedulers.Schedulers
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
 
 fun loadContributorsReactive(
     service: GitHubService,
     req: RequestData,
-    callback: (List<User>, completed: Boolean) -> Unit
-) {
+    scheduler: Scheduler = Schedulers.io()
+): Single<List<User>> {
     val repos: Observable<Repo> = service
         .getOrgReposRx(req.org)
-        .subscribeOn(Schedulers.io())
+        .subscribeOn(scheduler)
         .doOnNext { response -> logRepos(req, response) }
         .flatMapIterable { it.bodyList() }
 
     val allUsers: Single<List<User>> = repos
         .flatMap { repo ->
             service.getRepoContributorsRx(req.org, repo.name)
-                .subscribeOn(Schedulers.io())
+                .subscribeOn(scheduler)
                 .doOnNext { response -> logUsers(repo, response) }
         }
         .flatMapIterable { it.bodyList() }
         .toList()
 
-    allUsers
-        .doOnSuccess { callback(it.aggregate(), true) }
-        .subscribe()
+    return allUsers
+        .map { it.aggregate() }
 }

--- a/test/contributors/MockGithubService.kt
+++ b/test/contributors/MockGithubService.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.delay
 import retrofit2.Call
 import retrofit2.Response
 import retrofit2.mock.Calls
+import java.util.concurrent.TimeUnit
 
 object MockGithubService : GitHubService {
     override fun getOrgReposCall(org: String): Call<List<Repo>> {
@@ -26,11 +27,13 @@ object MockGithubService : GitHubService {
         return Response.success(testRepo.users)
     }
 
-    override fun getOrgReposRx(org: String): Observable<Response<List<Repo>>> {
-        TODO()
-    }
+    override fun getOrgReposRx(org: String): Observable<Response<List<Repo>>> = Observable
+        .just(Response.success(repos))
+        .delay(reposDelay, TimeUnit.MILLISECONDS, testScheduler)
 
     override fun getRepoContributorsRx(owner: String, repo: String): Observable<Response<List<User>>> {
-        TODO()
+        val testRepo = reposMap.getValue(repo)
+        return Observable.just(Response.success(testRepo.users))
+            .delay(testRepo.delay, TimeUnit.MILLISECONDS, testScheduler)
     }
 }

--- a/test/contributors/testData.kt
+++ b/test/contributors/testData.kt
@@ -1,5 +1,7 @@
 package contributors
 
+import io.reactivex.schedulers.TestScheduler
+
 val testRequestData = RequestData("username", "password", "org")
 
 data class TestRepo(val name: String, val delay: Long, val users: List<User>)
@@ -72,3 +74,5 @@ val concurrentProgressResults = listOf(
     ),
     expectedConcurrentResults
 )
+
+val testScheduler = TestScheduler()

--- a/test/tasks/Request8RxKtTest.kt
+++ b/test/tasks/Request8RxKtTest.kt
@@ -1,0 +1,36 @@
+package tasks
+
+import contributors.MockGithubService
+import contributors.expectedConcurrentResults
+import contributors.testRequestData
+import contributors.testScheduler
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+internal class Request8RxKtTest {
+
+    @Before
+    fun setUp() {
+        testScheduler.advanceTimeTo(0, TimeUnit.MILLISECONDS)
+    }
+
+    @Test
+    fun loadContributorsReactive() {
+        val testObserver = loadContributorsReactive(MockGithubService, testRequestData, testScheduler).test()
+        testObserver.assertNoValues()
+
+        val startTime = testScheduler.now(TimeUnit.MILLISECONDS)
+        testScheduler.advanceTimeBy(expectedConcurrentResults.timeFromStart, TimeUnit.MILLISECONDS)
+        testObserver.assertValue(expectedConcurrentResults.users)
+
+        val totalTime = testScheduler.now(TimeUnit.MILLISECONDS) - startTime
+        Assert.assertEquals(
+            "The calls run concurrently, so the total virtual time should be 2200 ms: " +
+                    "1000 ms for repos request plus max(1000, 1200, 800) = 1200 ms for concurrent contributors requests)",
+            expectedConcurrentResults.timeFromStart, totalTime
+        )
+    }
+
+}

--- a/test/tasks/Request9RxProgressKtTest.kt
+++ b/test/tasks/Request9RxProgressKtTest.kt
@@ -1,0 +1,34 @@
+package tasks
+
+import contributors.*
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+internal class Request9RxProgressKtTest {
+
+    @Before
+    fun setUp() {
+        testScheduler.advanceTimeTo(0, TimeUnit.MILLISECONDS)
+    }
+
+    @Test
+    fun loadContributorsReactiveProgress() {
+        val testObserver = loadContributorsReactiveProgress(MockGithubService, testRequestData, testScheduler).test()
+        testObserver.assertNoValues()
+
+        val startTime = testScheduler.now(TimeUnit.MILLISECONDS)
+
+        concurrentProgressResults.forEachIndexed { index: Int, expected: TestResults ->
+            println("index: $index, expected: $expected")
+            testScheduler.advanceTimeTo(expected.timeFromStart, TimeUnit.MILLISECONDS)
+            testObserver.assertValueAt(index, expected.users)
+
+            val time = testScheduler.now(TimeUnit.MILLISECONDS) - startTime
+            Assert.assertEquals("Expected intermediate result after virtual ${expected.timeFromStart} ms:",
+                expected.timeFromStart, time)
+        }
+        testObserver.assertComplete()
+    }
+}


### PR DESCRIPTION
This PR adds a comparison of a couple more features of RX with coroutines.
RX has a [virtual time](https://github.com/softartdev/intro-coroutines/blob/rx/test/tasks/Request8RxKtTest.kt#L24) within [TestScheduler](https://github.com/softartdev/intro-coroutines/blob/rx/test/tasks/Request9RxProgressKtTest.kt#L25) as well.
Also, the [subscribe](https://github.com/softartdev/intro-coroutines/blob/rx/src/contributors/Contributors.kt#L119) method returns [Disposable](https://github.com/softartdev/intro-coroutines/blob/rx/src/contributors/Contributors.kt#L201), which allows you to [cancel](https://github.com/softartdev/intro-coroutines/blob/rx/src/contributors/Contributors.kt#L210) the execution.
Thanks for the lab. Having learned that coroutines have the same capabilities that I need from RX (you could also mention the Flow replacing the Observable), I begin to switch from RX to coroutines.