### PR TITLE
Use the right variable name in the commented assertion

### DIFF
--- a/test/tasks/Request7ChannelsKtTest.kt
+++ b/test/tasks/Request7ChannelsKtTest.kt
@@ -19,7 +19,7 @@ class Request7ChannelsKtTest {
             /*
             // TODO: uncomment this assertion
             Assert.assertEquals("Expected intermediate result after virtual ${expected.timeFromStart} ms:",
-                expected.timeFromStart, virtualTime)
+                expected.timeFromStart, time)
             */
             Assert.assertEquals("Wrong intermediate result after $time:", expected.users, users)
         }


### PR DESCRIPTION
Simply uncommenting the assertion with the current version on master results in a compilation error. Obviously a typo the compiler couldn't catch :)