### PR TITLE
Updated dependency versions and fixed deprecations for kotlinx-coroutines 1.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.5.20'
-    id 'org.jetbrains.kotlin.plugin.serialization' version '1.5.20'
+    id 'org.jetbrains.kotlin.jvm' version '1.7.21'
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.7.21'
 }
 
 group 'intro-coroutines'
@@ -13,42 +13,42 @@ repositories {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
     implementation "org.jetbrains.kotlin:kotlin-reflect"
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1")
 
-    def coroutines_version = '1.5.1'
+    def coroutines_version = '1.6.4'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-swing:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-debug:$coroutines_version"
 
-    implementation 'ch.qos.logback:logback-classic:1.2.3'
+    implementation 'ch.qos.logback:logback-classic:1.4.5'
 
     def retrofit_version = '2.9.0'
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.retrofit2:retrofit-mock:$retrofit_version"
     implementation "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0"
-    implementation 'com.squareup.okhttp3:okhttp:4.9.1'
+    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
 
     implementation 'io.reactivex.rxjava2:rxjava:2.2.21'
     implementation 'io.reactivex.rxjava2:rxkotlin:2.4.0'
     implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofit_version"
 
-    testImplementation "junit:junit:4.12"
+    testImplementation 'junit:junit:4.13.2'
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 }
 
 compileKotlin {
     kotlinOptions {
         jvmTarget = "1.8"
-        freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+        freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
     }
 }
 
 compileTestKotlin {
     kotlinOptions {
         jvmTarget = "1.8"
-        freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+        freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip

--- a/src/contributors/Contributors.kt
+++ b/src/contributors/Contributors.kt
@@ -3,11 +3,11 @@ package contributors
 import contributors.Contributors.LoadingStatus.*
 import contributors.Variant.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.swing.Swing
 import tasks.*
 import java.awt.event.ActionListener
 import javax.swing.SwingUtilities
 import kotlin.coroutines.CoroutineContext
+import kotlin.system.exitProcess
 
 enum class Variant {
     BLOCKING,         // Request1Blocking
@@ -38,7 +38,7 @@ interface Contributors: CoroutineScope {
         addOnWindowClosingListener {
             job.cancel()
             saveParams()
-            System.exit(0)
+            exitProcess(0)
         }
 
         // Load stored params (user & password values)

--- a/src/contributors/ContributorsUI.kt
+++ b/src/contributors/ContributorsUI.kt
@@ -19,7 +19,7 @@ class ContributorsUI : JFrame("GitHub Contributors"), Contributors {
     private val username = JTextField(20)
     private val password = JPasswordField(20)
     private val org = JTextField(20)
-    private val variant = JComboBox<Variant>(Variant.values())
+    private val variant = JComboBox(Variant.values())
     private val load = JButton("Load contributors")
     private val cancel = JButton("Cancel").apply { isEnabled = false }
 

--- a/test/contributors/testData.kt
+++ b/test/contributors/testData.kt
@@ -32,7 +32,7 @@ val testRepos = listOf(
 
 val repos = testRepos.mapIndexed { index, testRepo -> Repo(index.toLong(), testRepo.name) }
 
-val reposMap = testRepos.associate { it.name to it }
+val reposMap = testRepos.associateBy { it.name }
 
 val expectedResults = TestResults(
     4000, // 1000 + (1000 + 1200 + 800)

--- a/test/samples/SampleTest.kt
+++ b/test/samples/SampleTest.kt
@@ -4,13 +4,14 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class SampleTest {
     @Test
-    fun testDelayInSuspend() = runBlockingTest {
+    fun testDelayInSuspend() = runTest {
         val realStartTime = System.currentTimeMillis()
         val virtualStartTime = currentTime
 
@@ -26,7 +27,7 @@ class SampleTest {
     }
 
     @Test
-    fun testDelayInLaunch() = runBlockingTest {
+    fun testDelayInLaunch() = runTest {
         val realStartTime = System.currentTimeMillis()
         val virtualStartTime = currentTime
 


### PR DESCRIPTION
- updated to Kotlin 1.7.21, kotlinx-coroutines 1.6.4, gradle 7.6
- `runBlockingTest` is deprecated, was replaced with `runTest`, proper import was added for `currentTime`
- cleaned up some other deprecations, implemented improvement suggestions